### PR TITLE
feat: make the shortcut platform specific as default and configurable by the user

### DIFF
--- a/cursorless.nvim/lua/cursorless/config.lua
+++ b/cursorless.nvim/lua/cursorless/config.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+local function default_shortcut()
+  local windows_shortcut = "<C-S-F12>"
+  local unix_shortcut = "<C-`>"
+  return require("cursorless.utils").is_platform_windows() and windows_shortcut
+    or unix_shortcut
+end
+
+local config = {
+  shortcut = default_shortcut(),
+}
+
+function M.set_config(user_config)
+  return vim.tbl_deep_extend("force", config, user_config or {})
+end
+
+function M.get_config()
+  return config
+end
+
+return M

--- a/cursorless.nvim/lua/cursorless/init.lua
+++ b/cursorless.nvim/lua/cursorless/init.lua
@@ -1,3 +1,4 @@
+local M
 local function register_functions()
   local utils = require("cursorless.utils")
   local path = utils.cursorless_nvim_path()
@@ -65,50 +66,31 @@ end
 -- https://stackoverflow.com/questions/7642746/is-there-any-way-to-view-the-currently-mapped-keys-in-vim
 -- luacheck:ignore 631
 -- https://stackoverflow.com/questions/3776117/what-is-the-difference-between-the-remap-noremap-nnoremap-and-vnoremap-mapping
-local function configure_command_server_shortcut()
+local function configure_command_server_shortcut(shortcut)
   -- these mappings don't change the current mode
   -- https://neovim.io/doc/user/api.html#nvim_set_keymap()
   -- https://www.reddit.com/r/neovim/comments/pt92qn/mapping_cd_in_terminal_mode/
-  vim.api.nvim_set_keymap(
-    "i",
-    "<C-S-F12>",
-    "<cmd>lua vim.fn.CommandServerRunCommand()<CR>",
-    { noremap = true }
-  )
-  vim.api.nvim_set_keymap(
-    "n",
-    "<C-S-F12>",
-    "<cmd>lua vim.fn.CommandServerRunCommand()<CR>",
-    { noremap = true }
-  )
-  vim.api.nvim_set_keymap(
-    "c",
-    "<C-S-F12>",
-    "<cmd>lua vim.fn.CommandServerRunCommand()<CR>",
-    { noremap = true }
-  )
-  vim.api.nvim_set_keymap(
-    "v",
-    "<C-S-F12>",
-    "<cmd>lua vim.fn.CommandServerRunCommand()<CR>",
-    { noremap = true }
-  )
-  vim.api.nvim_set_keymap(
-    "t",
-    "<C-S-F12>",
-    "<cmd>lua vim.fn.CommandServerRunCommand()<CR>",
-    { noremap = true }
-  )
+  local modes = { "i", "n", "c", "v", "t" }
+  for _, mode in ipairs(modes) do
+    vim.api.nvim_set_keymap(
+      mode,
+      shortcut,
+      "<cmd>lua vim.fn.CommandServerRunCommand()<CR>",
+      { noremap = true }
+    )
+  end
 end
 
-local function setup()
+local function setup(user_config)
+  local config = require("cursorless.config").set_config(user_config)
   register_functions()
   load_extensions()
-  configure_command_server_shortcut()
+  configure_command_server_shortcut(config.shortcut)
 end
 
-local M = {
+M = {
   setup = setup,
+  config = require("cursorless.config").get_config,
 }
 
 return M


### PR DESCRIPTION
As discussed, make the shortcut configurable. This is complimentary to https://github.com/hands-free-vim/neovim-talon/pull/7, until something like https://github.com/hands-free-vim/neovim-talon/issues/6 is fixed.