### PR TITLE
refactor: cleanup names and better expose cursorless lua funcs

### DIFF
--- a/cursorless.nvim/lua/cursorless/cursorless.lua
+++ b/cursorless.nvim/lua/cursorless/cursorless.lua
@@ -3,7 +3,7 @@ local M = {}
 -- Get the first and last visible line of the current window/buffer
 -- @see https://vi.stackexchange.com/questions/28471/get-first-and-last-visible-line-from-other-buffer-than-current
 -- w0/w$ are indexed from 1, similarly to what is shown in neovim
--- e.g. :lua print(dump_table(require('talon.cursorless').window_get_visible_lines()))"
+-- e.g. :lua print(vim.inspect(require('cursorless').window_get_visible_lines()))"
 --   window_get_visible_lines
 --  { [1] = 28, [2] = 74 }
 function M.window_get_visible_lines()
@@ -15,7 +15,7 @@ end
 -- https://neovim.io/doc/user/api.html#nvim_win_get_cursor()
 --
 -- luacheck:ignore 631
--- e.g. run in command mode :vmap <c-a> <Cmd>lua print(vim.inspect(require('talon.cursorless').buffer_get_selection()))<Cr>
+-- e.g. run in command mode :vmap <c-a> <Cmd>lua print(vim.inspect(require('cursorless').buffer_get_selection()))<Cr>
 -- then go in visual mode with "v" and select "hello" on the first line and continue selection with "air"
 -- on the second line.
 -- Then hit ctrl+b and it will show the selection
@@ -89,7 +89,7 @@ end
 
 -- https://www.reddit.com/r/neovim/comments/p4u4zy/how_to_pass_visual_selection_range_to_lua_function/
 -- luacheck:ignore 631
--- e.g. run in command mode :vmap <c-b> <Cmd>lua print(vim.inspect(require('talon.cursorless').buffer_get_selection_text()))<Cr>
+-- e.g. run in command mode :vmap <c-b> <Cmd>lua print(vim.inspect(require('cursorless').buffer_get_selection_text()))<Cr>
 -- then go in visual mode with "v" and select "hello" on the first line and continue selection with "air"
 -- on the second line.
 -- Then hit ctrl+b and it will show the selection

--- a/cursorless.nvim/lua/cursorless/init.lua
+++ b/cursorless.nvim/lua/cursorless/init.lua
@@ -89,7 +89,7 @@ local function setup(user_config)
 end
 
 local cursorless = require("cursorless.cursorless")
-local M = {
+M = {
   setup = setup,
   config = require("cursorless.config").get_config,
   window_get_visible_lines = cursorless.window_get_visible_lines,

--- a/cursorless.nvim/lua/cursorless/init.lua
+++ b/cursorless.nvim/lua/cursorless/init.lua
@@ -107,8 +107,13 @@ local function setup()
   configure_command_server_shortcut()
 end
 
+local cursorless = require("cursorless.cursorless")
 local M = {
   setup = setup,
+  window_get_visible_lines = cursorless.window_get_visible_lines,
+  buffer_get_selection = cursorless.buffer_get_selection,
+  buffer_get_selection_text = cursorless.buffer_get_selection_text,
+  select_range = cursorless.select_range,
 }
 
 return M

--- a/cursorless.nvim/lua/cursorless/utils.lua
+++ b/cursorless.nvim/lua/cursorless/utils.lua
@@ -7,7 +7,7 @@ end
 
 -- :lua print(require('cursorless.utils').get_path_separator())
 function M.get_path_separator()
-  if require("cursorless.utils").is_platform_windows() then
+  if M.is_platform_windows() then
     return "\\"
   end
   return "/"
@@ -26,7 +26,7 @@ function M.cursorless_nvim_path()
   -- skip as the file name is prefixed by "@"
   str = str:sub(2)
   -- print(('source_file2=%s'):format(str))
-  if require("cursorless.utils").is_platform_windows() then
+  if M.is_platform_windows() then
     str = str:gsub("/", "\\")
     -- print('is_platform_windows')
   end

--- a/packages/neovim-common/src/ide/neovim/NeovimClipboard.ts
+++ b/packages/neovim-common/src/ide/neovim/NeovimClipboard.ts
@@ -1,15 +1,15 @@
 import type { Clipboard } from "@cursorless/common";
-import { getFromClipboard, putToClipboard } from "../../neovimApi";
+import { getClipboard, setClipboard } from "../../neovimApi";
 import type { NeovimClient } from "neovim";
 
 export default class NeovimClipboard implements Clipboard {
   constructor(private client: NeovimClient) {}
 
   async readText(): Promise<string> {
-    return await getFromClipboard(this.client);
+    return await getClipboard(this.client);
   }
 
   async writeText(value: string): Promise<void> {
-    return await putToClipboard(value, this.client);
+    return await setClipboard(value, this.client);
   }
 }

--- a/packages/neovim-common/src/neovimApi.ts
+++ b/packages/neovim-common/src/neovimApi.ts
@@ -13,7 +13,7 @@ export async function bufferGetSelections(
   window: Window,
   client: NeovimClient,
 ): Promise<Selection[]> {
-  const luaCode = `return require("cursorless.cursorless").buffer_get_selection()`;
+  const luaCode = `return require("cursorless").buffer_get_selection()`;
   // Note lines are indexed from 1, similarly to what is shown in neovim
   // and columns are also indexed from 1
   const [startLine, startCol, endLine, endCol, reverse] =
@@ -60,7 +60,7 @@ export async function bufferSetSelections(
   // cursorless has 0-based lines/columns, but neovim has 1-based lines and 0-based columns
   // also, experience shows we need to subtract 1 from the end character to stop on it in visual mode (instead of after it)
   // https://neovim.io/doc/user/api.html#nvim_win_set_cursor()
-  const luaCode = `return require("cursorless.cursorless").select_range(${
+  const luaCode = `return require("cursorless").select_range(${
     selections[0].start.line + 1
   }, ${selections[0].start.character}, ${selections[0].end.line + 1}, ${
     selections[0].end.character
@@ -85,7 +85,7 @@ export async function windowGetVisibleRanges(
 ): Promise<Range[]> {
   // Get the first and last visible lines of the current window
   // Note they are indexed from 1, similarly to what is shown in neovim*
-  const luaCode = `return require("cursorless.cursorless").window_get_visible_lines()`;
+  const luaCode = `return require("cursorless").window_get_visible_lines()`;
   const [firstLine, lastLine] = (await client.executeLua(luaCode, [])) as [
     number,
     number,
@@ -116,7 +116,7 @@ export async function getCursorlessNvimPath(
  * https://stackoverflow.com/questions/11489428/how-can-i-make-vim-paste-from-and-copy-to-the-systems-clipboard?page=1&tab=scoredesc#tab-top
  * https://stackoverflow.com/questions/30691466/what-is-difference-between-vims-clipboard-unnamed-and-unnamedplus-settings
  */
-export async function putToClipboard(data: string, client: NeovimClient) {
+export async function setClipboard(data: string, client: NeovimClient) {
   await client.callFunction("setreg", ["*", data]);
 }
 
@@ -124,7 +124,7 @@ export async function putToClipboard(data: string, client: NeovimClient) {
  * Return the string from the operating system clipboard
  * https://vimdoc.sourceforge.net/htmldoc/eval.html#getreg()
  */
-export async function getFromClipboard(client: NeovimClient): Promise<string> {
+export async function getClipboard(client: NeovimClient): Promise<string> {
   return await client.callFunction("getreg", ["*"]);
 }
 

--- a/packages/neovim-common/src/neovimHelpers.ts
+++ b/packages/neovim-common/src/neovimHelpers.ts
@@ -3,7 +3,7 @@
 import {
   bufferGetSelections,
   pasteFromClipboard,
-  putToClipboard,
+  setClipboard,
 } from "@cursorless/neovim-common";
 import { NeovimTextEditorImpl } from "./ide/neovim/NeovimTextEditorImpl";
 import type { NeovimClient } from "neovim";
@@ -17,7 +17,7 @@ export async function neovimClipboardCopy(
   const window = await client.window;
   const selections = await bufferGetSelections(window, client);
   const data = editor.document.getText(selections[0]);
-  await putToClipboard(data, client);
+  await setClipboard(data, client);
 }
 
 export async function neovimClipboardPaste(


### PR DESCRIPTION
This mostly cleans up the lua and a couple comments. It makes calling the core cursorless functions exposed by the lua a bit cleaner in the typescript (I think `require('cursorless.cursorless'` is gross). I also rename two typescript function names. "putToClipboard" isn't really correct english (imo) so reads weird. I think getClipboard and setClipboard is better and matches getreg and setreg