### PR TITLE
feat: Add tasks for debugging neovim on linux

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -205,7 +205,12 @@
           "tell app \"Terminal\" to do script \"${workspaceFolder}/packages/cursorless-neovim/scripts/debug-neovim.sh ${workspaceFolder} development\" activate"
         ]
       },
-      // TODO: Add linux
+      "linux": {
+        "command": "packages/cursorless-neovim/scripts/linux-terminal.sh",
+        "args": [
+          "${workspaceFolder}/packages/cursorless-neovim/scripts/debug-neovim.sh ${workspaceFolder} development"
+        ]
+      },
       "group": "build",
       "options": {
         "env": {
@@ -233,7 +238,12 @@
           "tell app \"Terminal\" to do script \"${workspaceFolder}/packages/cursorless-neovim/scripts/debug-neovim.sh ${workspaceFolder} test\" activate"
         ]
       },
-      // TODO: Add linux
+      "linux": {
+        "command": "packages/cursorless-neovim/scripts/linux-terminal.sh",
+        "args": [
+          "${workspaceFolder}/packages/cursorless-neovim/scripts/debug-neovim.sh ${workspaceFolder} test"
+        ]
+      },
       "group": "build",
       "options": {
         "env": {

--- a/docs/contributing/cursorless-in-neovim.md
+++ b/docs/contributing/cursorless-in-neovim.md
@@ -35,7 +35,8 @@ Note that the `C:\path\to\cursorless` path above should match your cloned cursor
 
 ## Running / testing extension locally
 
-In order to test out your local version of the extension or to run unit tests locally, you need to run the extension in debug mode. To do so you need to run the `workbench.action.debug.selectandstart` command in VSCode and then select either "Run neovim extension" or "Run neovim extension tests".
+In order to test out your local version of the extension or to run unit tests locally, you need to run the extension in
+debug mode. To do so you need to run the `workbench.action.debug.selectandstart` (aka `Debug: Select and Start Debugging`) command in VSCode and then select either "Neovim: Run" or "Neovim: Test".
 
 The debug logs are written in `C:\path\to\cursorless\packages\cursorless-neovim\out\nvim_node.log`.
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709675310,
-        "narHash": "sha256-w61tqFEmuJ+/1rAwU7nkYZ+dN6sLwyobfLwX2Yn42FE=",
+        "lastModified": 1718870667,
+        "narHash": "sha256-jab3Kpc8O1z3qxwVsCMHL4+18n5Wy/HHKyu1fcsF7gs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "43d259f8d726113fac056e8bb17d5ac2dea3e0a8",
+        "rev": "9b10b8f00cb5494795e5f51b39210fed4d2b0748",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,9 @@
 {
   description = "A Nix-flake-based development environment for Cursorless";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
 
   outputs =
     { self, nixpkgs }:
@@ -13,7 +15,43 @@
         "aarch64-darwin"
       ];
       forEachSupportedSystem =
-        f: nixpkgs.lib.genAttrs supportedSystems (system: f { pkgs = import nixpkgs { inherit system; }; });
+        f:
+        nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [
+                # https://github.com/NixOS/nixpkgs/pull/317333
+                (final: prev: {
+                  nodePackages = prev.nodePackages // {
+                    neovim = prev.buildNpmPackage rec {
+                      pname = "neovim-node-client";
+                      version = "5.1.1-dev.0";
+                      src = prev.fetchFromGitHub {
+                        owner = "neovim";
+                        repo = "node-client";
+                        rev = "d99ececf115ddc8ade98467417c1bf0120b676b5";
+                        hash = "sha256-eiKyhJNz7kH2iX55lkn7NZYTj6yaSZLMZxqiqPxDIPs=";
+                      };
+                      npmDeps = prev.fetchNpmDeps {
+                        inherit src;
+                        hash = "sha256-UoMq+7evskxtZygycxLBgeUtwrET8jYKeZwMiXdBMAw=";
+                      };
+                      postInstall = ''
+                        mkdir -p $out/bin
+                        ln -s $out/lib/node_modules/neovim/node_modules/.bin/neovim-node-host $out/bin
+                      '';
+                    };
+                  };
+                  neovim = prev.neovim.override { withNodeJs = true; };
+
+                })
+
+              ];
+            };
+          }
+        );
       pythonVersion = builtins.replaceStrings [ "py" ] [
         "python"
       ] (nixpkgs.lib.importTOML ./pyproject.toml).tool.ruff.target-version;
@@ -37,8 +75,8 @@
                     --set PYTHONPATH $PYTHONPATH
                   '';
                 }))
-
                 python
+                pkgs.neovim
               ];
             # To prevent weird broken non-interactive bash terminal
             buildInputs = [ pkgs.bashInteractive ];
@@ -46,8 +84,9 @@
               if [ ! -f .git/hooks/pre-commit ]; then
                 echo "You can run 'pre-commit install' to install git commit hooks if you want them."
               fi
-
               pnpm install
+
+              PATH=${pkgs.lib.getBin pkgs.neovim}/bin:$PATH}
             '';
           };
         }

--- a/init.lua
+++ b/init.lua
@@ -17,6 +17,9 @@ require("lazy").setup({
 })
 
 local repo_root = os.getenv("CURSORLESS_REPO_ROOT")
+if not repo_root then
+  error("CURSORLESS_REPO_ROOT is not set. Run via debug-neovim.sh script.")
+end
 vim.opt.runtimepath:append(repo_root .. "/cursorless.nvim")
 
 require("talon").setup()

--- a/packages/cursorless-neovim/scripts/debug-neovim.sh
+++ b/packages/cursorless-neovim/scripts/debug-neovim.sh
@@ -10,4 +10,4 @@ export NVIM_NODE_LOG_FILE="${workspaceFolder}/packages/cursorless-neovim/out/nvi
 export NVIM_NODE_LOG_LEVEL="info"
 export CURSORLESS_MODE="${cursorless_mode}"
 
-nvim -u "${workspaceFolder}/init.lua"
+command nvim -u "${workspaceFolder}/init.lua"

--- a/packages/cursorless-neovim/scripts/linux-terminal.sh
+++ b/packages/cursorless-neovim/scripts/linux-terminal.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2068
+set -euo pipefail
+
+if command -v gnome-terminal &>/dev/null; then
+  # FIXME: Possibly have to use ;exec bash to not auto-close the terminal
+  gnome-terminal -- $@
+elif command -v gnome-console &>/dev/null; then
+  gnome-console -- $@
+elif command -v konsole &>/dev/null; then
+  konsole --hold -e $@
+elif command -v xfce4-terminal &>/dev/null; then
+  xfce4-terminal --hold -e $@
+elif command -v kitty &>/dev/null; then
+  kitty -1 --hold $@
+elif command -v alacritty &>/dev/null; then
+  alacritty --hold -e $@
+elif command -v wezterm &>/dev/null; then
+  wezterm --config "exit_behavior='Hold'" start --always-new-process $@
+else
+  echo "No supported terminal emulator found. File an issue to get it added."
+  exit 1
+fi

--- a/packages/cursorless-neovim/scripts/populate-dist.sh
+++ b/packages/cursorless-neovim/scripts/populate-dist.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 echo "Populating dist directory..."
+if [ ! -e "${CURSORLESS_REPO_ROOT-nonexistent}" ]; then
+  CURSORLESS_REPO_ROOT=$(git rev-parse --show-toplevel)
+fi
 echo "CURSORLESS_REPO_ROOT: $CURSORLESS_REPO_ROOT"
 cursorless_nvim_dir="$CURSORLESS_REPO_ROOT/cursorless.nvim"
 cursorless_neovim_node_in_dir="$CURSORLESS_REPO_ROOT/packages/cursorless-neovim"


### PR DESCRIPTION
This should close https://github.com/cursorless-dev/cursorless/issues/2366, as @pokey added OS X tests already. We can't assume what terminal exists on the linux development machine so I added a way to invoke a bunch of the common ones. The caveat here is that you might end up having multiple terminals installed and it could run a terminal that you prefer isn't the default, but I don't think that's a huge deal atm.

There's obviously lots of other terminals that I didn't add but I think this is good enough for now and we can add more in the unlikely event other developers crop up that run into others.

I haven't got as far as being able to actually run the tests yet, but that's due to a bug I need to hunt down that's separate from these tasks. These both at least run and allow me to debug them on attach.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
