### PR TITLE
refactor: improve cursorless.lua function readability

### DIFF
--- a/cursorless.nvim/lua/cursorless/cursorless.lua
+++ b/cursorless.nvim/lua/cursorless/cursorless.lua
@@ -7,118 +7,44 @@ local M = {}
 --   window_get_visible_lines
 --  { [1] = 28, [2] = 74 }
 function M.window_get_visible_lines()
-  -- print('window_get_visible_lines()')
-  return { vim.fn.line("w0"), vim.fn.line("w$") }
+	-- print('window_get_visible_lines()')
+	return { vim.fn.line("w0"), vim.fn.line("w$") }
 end
 
--- https://www.reddit.com/r/neovim/comments/p4u4zy/how_to_pass_visual_selection_range_to_lua_function/
--- https://neovim.io/doc/user/api.html#nvim_win_get_cursor()
+-- Get the coordinates of the current selection
+-- To manually test follow these steps:
+-- 1. In command mode :vmap <c-a> <Cmd>lua print(vim.inspect(require('cursorless').buffer_get_selection()))<Cr>
+-- 2. type "hello" on the first line and "world" on the second line
+-- 3. Enter visual mode and select "hello" on the first line and continue selection with "air"
+--    on the second line.
+-- 4. Hit ctrl+b to show the selection: {1, 1, 2, 5, false}
+-- 5. Hit 'o' to swap the cursor position and hit ctrl+b again: {1, 1, 2, 5, true}
 --
--- luacheck:ignore 631
--- e.g. run in command mode :vmap <c-a> <Cmd>lua print(vim.inspect(require('talon.cursorless').buffer_get_selection()))<Cr>
--- then go in visual mode with "v" and select "hello" on the first line and continue selection with "air"
--- on the second line.
--- Then hit ctrl+b and it will show the selection
--- cline=2, ccol=2, vline=1, vcol=1
--- sline=1, scol=1, eline=2, ecol=3, reverse=false
--- { 1, 1, 2, 3, false }
---
--- if instead you select from the end of the "air" word on the second line
--- and select up to the beginning of "hello" on the first line
--- cline=1, ccol=0, vline=3, vcol=3
--- sline=1, scol=1, eline=2, ecol=3, reverse=true
--- { 1, 1, 2, 3, true }
---
--- if you want to directly see how it is parsed in the node extension, you can use the below:
--- e.g. run in command mode :vmap <c-a> <Cmd>:call CursorlessLoadExtension()<Cr>
--- and again use ctrl+a after selecting the text
+-- If you want to directly see how it is parsed in the node extension:
+-- 1. run in command mode :vmap <c-a> <Cmd>:call CursorlessLoadExtension()<Cr>
+-- 2. Select some text and hit ctrl+a
 function M.buffer_get_selection()
-  -- print('buffer_get_selection()')
-  local modeInfo = vim.api.nvim_get_mode()
-  local mode = modeInfo.mode
+	local start_pos = vim.fn.getpos("v") -- start of visual selection
+	local start_line, start_col = start_pos[2], start_pos[3]
+	local end_pos = vim.fn.getpos(".") -- end of visual selection (cursor position)
+	local end_line, end_col = end_pos[2], end_pos[3]
+	local reverse = false
+	local mode = vim.api.nvim_get_mode().mode
 
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local cline, ccol = cursor[1], cursor[2]
-  local vline, vcol = vim.fn.line("v"), vim.fn.col("v")
-  -- print(('cline=%d, ccol=%d, vline=%d, vcol=%d'):format(cline, ccol, vcol, vcol))
+	-- Invert the values depending on if the cursor is before the start
+	if end_line < start_line or end_col < start_col then
+		start_line, start_col, end_line, end_col = end_line, end_col, start_line, start_col
+		reverse = true
+	end
 
-  local sline, scol
-  local eline, ecol
-  local reverse
-  if cline == vline then
-    --   if ccol <= vcol then
-    if ccol < vcol then
-      sline, scol = cline, ccol
-      eline, ecol = vline, vcol
-      scol = scol + 1
-      reverse = true
-    else
-      sline, scol = vline, vcol
-      eline, ecol = cline, ccol
-      ecol = ecol + 1
-      reverse = false
-    end
-  elseif cline < vline then
-    sline, scol = cline, ccol
-    eline, ecol = vline, vcol
-    scol = scol + 1
-    reverse = true
-  else
-    sline, scol = vline, vcol
-    eline, ecol = cline, ccol
-    ecol = ecol + 1
-    reverse = false
-  end
+	-- See https://github.com/cursorless-dev/cursorless/issues/2537 if you want to add more modes
+	if mode == "V" then
+		-- Line and block-based visual modes are line-based, so we don't need to track the columns
+		start_col = 1
+		end_col = nil
+	end
 
-  if mode == "V" or mode == "CTRL-V" or mode == "\22" then
-    scol = 1
-    ecol = nil
-  end
-
-  -- print(
-  --   ('sline=%d, scol=%d, eline=%d, ecol=%d, reverse=%s'):format(
-  --     sline,
-  --     scol,
-  --     eline,
-  --     ecol,
-  --     tostring(reverse)
-  --   )
-  -- )
-  return { sline, scol, eline, ecol, reverse }
-end
-
--- https://www.reddit.com/r/neovim/comments/p4u4zy/how_to_pass_visual_selection_range_to_lua_function/
--- luacheck:ignore 631
--- e.g. run in command mode :vmap <c-b> <Cmd>lua print(vim.inspect(require('talon.cursorless').buffer_get_selection_text()))<Cr>
--- then go in visual mode with "v" and select "hello" on the first line and continue selection with "air"
--- on the second line.
--- Then hit ctrl+b and it will show the selection
--- { "hello", "air" }
-function M.buffer_get_selection_text()
-  -- print('buffer_get_selection_text()')
-  local sline, scol, eline, ecol, _ =
-    unpack(require("talon.cursorless").buffer_get_selection())
-
-  local lines = vim.api.nvim_buf_get_lines(0, sline - 1, eline, 0)
-  if #lines == 0 then
-    return
-  end
-
-  local startText, endText
-  if #lines == 1 then
-    startText = string.sub(lines[1], scol, ecol)
-  else
-    startText = string.sub(lines[1], scol)
-    endText = string.sub(lines[#lines], 1, ecol)
-  end
-
-  local selection = { startText }
-  if #lines > 2 then
-    vim.list_extend(selection, vim.list_slice(lines, 2, #lines - 1))
-  end
-  table.insert(selection, endText)
-
-  return selection
+	return { start_line, start_col, end_line, end_col, reverse }
 end
 
 -- https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/ts_utils.lua#L278
@@ -131,11 +57,11 @@ end
 -- for example it will highlight the last function name (nvim_win_set_cursor).
 -- another example is :tmap <c-b> <Cmd>lua require("talon.cursorless").select_range(4, 0, 4, 38)<Cr>
 -- NOTE: works for any mode (n,i,v,nt) except in t mode
-function M.select_range(start_x, start_y, end_x, end_y)
-  vim.cmd([[normal! :noh]])
-  vim.api.nvim_win_set_cursor(0, { start_x, start_y })
-  vim.cmd([[normal v]])
-  vim.api.nvim_win_set_cursor(0, { end_x, end_y })
+function M.select_range(start_line, start_col, end_line, end_col)
+	vim.cmd([[normal! :noh]])
+	vim.api.nvim_win_set_cursor(0, { start_line, start_col })
+	vim.cmd([[normal v]])
+	vim.api.nvim_win_set_cursor(0, { end_line, end_col })
 end
 
 return M


### PR DESCRIPTION
This refactors get_buffer_selection() to be readable.

I noticed the original is maybe a copy and paste from https://github.com/b0o/nvim-conf/blob/main/lua/user/util/visual.lua, which I'm not sure why they did it the way did, but seems overly complicated and hard to read.

Also the FIXME here I've kept for discussion, but IMO we can probably drop the `\22` and `CTRL-V` and file an issue instead, as I think these will be broken. But I left them in for functional equivalence.

All the existing cursorless tests that were passing still pass with this new version, so I think it's okay to use. This refactor will make it easier to fix bugs like #2322, because it will be easier to know if they are on the lua or typescript side.

I didn't add new test for this, because the test branch is still waiting for a PR. Once it gets in, we can add some. That said, I think for this particular function because cursorless is relying heavily on getting text selections, the original tests passing is a pretty good test anyway.