### PR TITLE
refactor: replace BufOnly plugin with two commands

### DIFF
--- a/cursorless.nvim/lua/cursorless/cursorless.lua
+++ b/cursorless.nvim/lua/cursorless/cursorless.lua
@@ -7,8 +7,8 @@ local M = {}
 --   window_get_visible_lines
 --  { [1] = 28, [2] = 74 }
 function M.window_get_visible_lines()
-	-- print('window_get_visible_lines()')
-	return { vim.fn.line("w0"), vim.fn.line("w$") }
+  -- print('window_get_visible_lines()')
+  return { vim.fn.line("w0"), vim.fn.line("w$") }
 end
 
 -- Get the coordinates of the current selection
@@ -24,27 +24,28 @@ end
 -- 1. run in command mode :vmap <c-a> <Cmd>:call CursorlessLoadExtension()<Cr>
 -- 2. Select some text and hit ctrl+a
 function M.buffer_get_selection()
-	local start_pos = vim.fn.getpos("v") -- start of visual selection
-	local start_line, start_col = start_pos[2], start_pos[3]
-	local end_pos = vim.fn.getpos(".") -- end of visual selection (cursor position)
-	local end_line, end_col = end_pos[2], end_pos[3]
-	local reverse = false
-	local mode = vim.api.nvim_get_mode().mode
+  local start_pos = vim.fn.getpos("v") -- start of visual selection
+  local start_line, start_col = start_pos[2], start_pos[3]
+  local end_pos = vim.fn.getpos(".") -- end of visual selection (cursor position)
+  local end_line, end_col = end_pos[2], end_pos[3]
+  local reverse = false
+  local mode = vim.api.nvim_get_mode().mode
 
-	-- Invert the values depending on if the cursor is before the start
-	if end_line < start_line or end_col < start_col then
-		start_line, start_col, end_line, end_col = end_line, end_col, start_line, start_col
-		reverse = true
-	end
+  -- Invert the values depending on if the cursor is before the start
+  if end_line < start_line or end_col < start_col then
+    start_line, start_col, end_line, end_col =
+      end_line, end_col, start_line, start_col
+    reverse = true
+  end
 
-	-- See https://github.com/cursorless-dev/cursorless/issues/2537 if you want to add more modes
-	if mode == "V" then
-		-- Line and block-based visual modes are line-based, so we don't need to track the columns
-		start_col = 1
-		end_col = nil
-	end
+  -- See https://github.com/cursorless-dev/cursorless/issues/2537 if you want to add more modes
+  if mode == "V" then
+    -- Line and block-based visual modes are line-based, so we don't need to track the columns
+    start_col = 1
+    end_col = nil
+  end
 
-	return { start_line, start_col, end_line, end_col, reverse }
+  return { start_line, start_col, end_line, end_col, reverse }
 end
 
 -- https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/ts_utils.lua#L278
@@ -58,10 +59,10 @@ end
 -- another example is :tmap <c-b> <Cmd>lua require("talon.cursorless").select_range(4, 0, 4, 38)<Cr>
 -- NOTE: works for any mode (n,i,v,nt) except in t mode
 function M.select_range(start_line, start_col, end_line, end_col)
-	vim.cmd([[normal! :noh]])
-	vim.api.nvim_win_set_cursor(0, { start_line, start_col })
-	vim.cmd([[normal v]])
-	vim.api.nvim_win_set_cursor(0, { end_line, end_col })
+  vim.cmd([[normal! :noh]])
+  vim.api.nvim_win_set_cursor(0, { start_line, start_col })
+  vim.cmd([[normal v]])
+  vim.api.nvim_win_set_cursor(0, { end_line, end_col })
 end
 
 return M

--- a/init.lua
+++ b/init.lua
@@ -13,7 +13,6 @@ end
 vim.opt.rtp:prepend(lazypath)
 require("lazy").setup({
   "hands-free-vim/talon.nvim",
-  "vim-scripts/BufOnly.vim",
 })
 
 local repo_root = os.getenv("CURSORLESS_REPO_ROOT")

--- a/packages/cursorless-neovim-e2e/src/suite/recorded.neovim.test.ts
+++ b/packages/cursorless-neovim-e2e/src/suite/recorded.neovim.test.ts
@@ -67,9 +67,8 @@ async function openNewTestEditor(
   await client.command(":enew");
 
   if (!openBeside) {
-    // close all the other buffers
-    // @see: https://stackoverflow.com/questions/4545275/vim-close-all-buffers-but-this-one
-    await client.command(":BufOnly!");
+    // close all the other buffers (<C-^> is needed because e# fails on unnamed buffers)
+    await client.command("execute '%bd!' | execute 'normal! \\<C-^>'");
   }
 
   // standardise newlines so we can easily split the lines

--- a/packages/test-harness/src/config/init.lua
+++ b/packages/test-harness/src/config/init.lua
@@ -1,8 +1,6 @@
 local temp_dir = os.getenv("TEMP_DIR")
 local repo_root = os.getenv("CURSORLESS_REPO_ROOT")
 
-vim.cmd("source " .. temp_dir .. "/BufOnly.vim/plugin/BufOnly.vim")
-
 vim.opt.runtimepath:append(temp_dir .. "/talon.nvim")
 vim.opt.runtimepath:append(repo_root .. "/dist/cursorless.nvim")
 

--- a/scripts/install-neovim-dependencies.sh
+++ b/scripts/install-neovim-dependencies.sh
@@ -3,5 +3,4 @@ set -euo pipefail
 
 npm install -g neovim@5.1.0
 
-git clone https://github.com/vim-scripts/BufOnly.vim ${TEMP_DIR}/BufOnly.vim
 git clone https://github.com/hands-free-vim/talon.nvim ${TEMP_DIR}/talon.nvim


### PR DESCRIPTION
While checking why BufOnly was being used, I realized we didn't need it, so this removes it.