### PR TITLE
fix: make show logs work on linux/osx again

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -136,14 +136,9 @@
       "dependsOn": [
         "Neovim: Launch neovim",
         "Neovim: ESBuild",
-        "Neovim: Populate dist"
+        "Neovim: Populate dist",
+        "Neovim: Show logs"
       ],
-      "osx": {
-        "dependsOn": ["Neovim: Show logs"]
-      },
-      "linux": {
-        "dependsOn": ["Neovim: Show logs"]
-      },
       "group": "build"
     },
     {
@@ -153,14 +148,9 @@
         "Neovim: ESBuild",
         "Neovim: Populate dist",
         "TSBuild",
-        "Build test harness"
+        "Build test harness",
+        "Neovim: Show logs"
       ],
-      "osx": {
-        "dependsOn": ["Neovim: Show logs"]
-      },
-      "linux": {
-        "dependsOn": ["Neovim: Show logs"]
-      },
       "group": "build"
     },
     {
@@ -246,8 +236,6 @@
       }
     },
     {
-      // NOTE: We don't have a way on Windows atm due to command with argument inside Run() not working
-      // so we need to show logs outside of vscode (see #2454)
       "label": "Neovim: Show logs",
       "type": "process",
       "osx": {
@@ -263,6 +251,11 @@
           "-f",
           "${workspaceFolder}/packages/cursorless-neovim/out/nvim_node.log"
         ]
+      },
+      "windows": {
+        // NOTE: We don't have a way on Windows atm due to command with argument inside Run() not working
+        // so we need to show logs outside of vscode (see #2454)
+        "command": "echo"
       }
     },
 


### PR DESCRIPTION
[921699082c2fc09855796ed28109f393208026af](https://github.com/saidelike/cursorless/commit/921699082c2fc09855796ed28109f393208026af) broke show logs on linux/osx likely due a bug in vscode, see here: https://github.com/cursorless-dev/cursorless/issues/2445#issuecomment-2238581181

My proposed fix for this is to make show logs a windows dependency still but just make it a nop... I just threw in an echo since I can't test, so @saidelike you'll have to test on windows to see what works. 

Open to other suggestions, but in light of the bug it seems like it's not possible to just not depend on it for windows?

I confirmed this makes it work again on Linux